### PR TITLE
Add hostname to SQL update where clause

### DIFF
--- a/library/X509/Job.php
+++ b/library/X509/Job.php
@@ -294,7 +294,11 @@ class Job
                 $this->db->update(
                     'x509_target',
                     ['latest_certificate_chain_id' => null],
-                    ['ip = ?' => static::binary($target->ip), 'port = ?' => $target->port]
+                    [
+                        'hostname = ?' => $target->hostname,
+                        'ip = ?'       => static::binary($target->ip),
+                        'port = ?'     => $target->port
+                    ]
                 );
 
                 $this->finishTarget();


### PR DESCRIPTION
Before, connection errors to SNI enabled hosts,
removed all other hosts from same IP and port.

fixes #65

Signed-off-by: Eric Lippmann <eric.lippmann@icinga.com>