### PR TITLE
Schema: Reduce index size

### DIFF
--- a/etc/schema/mysql-upgrade/v1.1.0.sql
+++ b/etc/schema/mysql-upgrade/v1.1.0.sql
@@ -1,0 +1,2 @@
+ALTER TABLE x509_target DROP INDEX x509_idx_target_ip_port_hostname;
+ALTER TABLE x509_target ADD INDEX x509_idx_target_ip_port (ip, port);

--- a/etc/schema/mysql.schema.sql
+++ b/etc/schema/mysql.schema.sql
@@ -88,5 +88,5 @@ CREATE TABLE x509_target (
   ctime timestamp NULL DEFAULT NULL,
   mtime timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (id),
-  INDEX x509_idx_target_ip_port_hostname (ip,port,hostname)
+  INDEX x509_idx_target_ip_port (ip, port)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
An index for ip + port really is enough for the x509_target table.

fixes #61 