### PR TITLE
module.info: name the module itself via Module:

### DIFF
--- a/module.info
+++ b/module.info
@@ -1,4 +1,4 @@
-Module: Certificate Monitoring
+Module: x509
 Version: 1.0.0
 Depends: ipl (>= 0.1)
 Depends: reactbundle (>= 0.4)


### PR DESCRIPTION
[You clearly told me](https://community.icinga.com/t/new-icinga-web-module-repo-naming-scheme/3775/2?u=al2klimov) that my current auto-discovery's base won't survive. But the only other option is broken – here's the fix.