### PR TITLE
ExpirationWidget: Fix progress bar for locales using comma as decimal seperator.

### DIFF
--- a/library/X509/ExpirationWidget.php
+++ b/library/X509/ExpirationWidget.php
@@ -76,7 +76,7 @@ class ExpirationWidget extends BaseHtmlElement
                 ['class' => 'progress-bar dont-print'],
                 Html::tag(
                     'div',
-                    ['style' => "width: {$ratio}%;", 'class' => "bg-stateful {$state}"],
+                    ['style' => sprintf('width: %.2F%%;', $ratio), 'class' => "bg-stateful {$state}"],
                     new HtmlString('&nbsp;')
                 )
             )


### PR DESCRIPTION
If the user selected a locale that uses comma instead of point as decimal seperator (e.g. German) the progress bar of the ExpirationWidget always showed 100%.
This is fixed by using sprintf() with uppercase F as specifier which is independent of the locale and always uses decimal point as seperator.