### PR TITLE
Adjust less variable usage

### DIFF
--- a/public/css/module.less
+++ b/public/css/module.less
@@ -77,7 +77,7 @@
 .cert-chain {
   .rounded-corners();
 
-  color: @text-color-light;
+  color: @text-color-inverted;
   font-size: 120%;
   font-weight: @font-weight-bold;
   padding: 0.75em;

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -77,7 +77,7 @@
 .cert-chain {
   .rounded-corners();
 
-  color: #fff;
+  color: @text-color-light;
   font-size: 120%;
   font-weight: @font-weight-bold;
   padding: 0.75em;


### PR DESCRIPTION
Not complete. There's a single `color: #fff` definition left that should also use a variable. (`@text-color-on-icinga-blue`?)