### PR TITLE
Fix integer overflow and log total IPs to be scanned within a CIDR

### DIFF
--- a/library/X509/Job.php
+++ b/library/X509/Job.php
@@ -102,6 +102,9 @@ class Job
             $ipv6 = filter_var($start_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
             $subnet = $ipv6 ? 128 : 32;
             $numIps = pow(2, ($subnet - $prefix)) - 2;
+
+            Logger::info('Scanning %d IPs in the CIDR %s.', $numIps, $cidr);
+
             $start = static::addrToNumber($start_ip);
             for ($i = 0; $i < $numIps; $i++) {
                 $ip = static::numberToAddr(gmp_add($start, $i), $ipv6);

--- a/library/X509/Job.php
+++ b/library/X509/Job.php
@@ -101,9 +101,9 @@ class Job
 //            }
             $ipv6 = filter_var($start_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
             $subnet = $ipv6 ? 128 : 32;
-            $ip_count = 1 << ($subnet - $prefix);
+            $numIps = pow(2, ($subnet - $prefix)) - 2;
             $start = static::addrToNumber($start_ip);
-            for ($i = 0; $i < $ip_count; $i++) {
+            for ($i = 0; $i < $numIps; $i++) {
                 $ip = static::numberToAddr(gmp_add($start, $i), $ipv6);
                 foreach (StringHelper::trimSplit($jobDescription->get('ports')) as $portRange) {
                     $pieces = StringHelper::trimSplit($portRange, '-');


### PR DESCRIPTION
Currently the number of IP addresses to be scanned is computed by bit shifting, this can very quickly lead to integer overflow on fairly large networks ( is only the case with IPV6). This PR fixes this by calculating the number of addresses with `2^n` using the `pow()` function, because this will be automatically cast to double if the result can' t be stored in an integer type.

fixes #110