### PR TITLE
x509ImportSource#getDb(): SET SESSION SQL_MODE as in the other getDb()s

### DIFF
--- a/library/X509/ProvidedHook/x509ImportSource.php
+++ b/library/X509/ProvidedHook/x509ImportSource.php
@@ -21,9 +21,15 @@ abstract class x509ImportSource extends ImportSourceHook
         $config = new Sql\Config(ResourceFactory::getResourceConfig(
             Config::module('x509')->get('backend', 'resource')
         ));
-        $config->options = [
+
+        $options = [
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_OBJ
         ];
+        if ($config->db === 'mysql') {
+            $options[PDO::MYSQL_ATTR_INIT_COMMAND] = "SET SESSION SQL_MODE='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE"
+                . ",NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
+        }
+        $config->options = $options;
 
         $conn = new Sql\Connection($config);
 


### PR DESCRIPTION
Otherwise MySQL 8 says:

```
ERROR 1055 (42000): Expression #4 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'x509.c.subject' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```

fixes #97
closes #116