### PR TITLE
Remove `Controller::getDb()` override

### DIFF
--- a/library/X509/Common/Database.php
+++ b/library/X509/Common/Database.php
@@ -16,16 +16,13 @@ trait Database
      *
      * @return  Sql\Connection
      */
-    protected function getDb(array $options = [])
+    protected function getDb(): Sql\Connection
     {
         $config = new Sql\Config(ResourceFactory::getResourceConfig(
             Config::module('x509')->get('backend', 'resource')
         ));
 
-        if (! isset($options[PDO::ATTR_DEFAULT_FETCH_MODE])) {
-            $options[PDO::ATTR_DEFAULT_FETCH_MODE] = PDO::FETCH_OBJ;
-        }
-
+        $options = [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_OBJ];
         if ($config->db === 'mysql') {
             $options[PDO::MYSQL_ATTR_INIT_COMMAND] = "SET SESSION SQL_MODE='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE"
                 . ",NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";

--- a/library/X509/Controller.php
+++ b/library/X509/Controller.php
@@ -10,18 +10,14 @@ use Icinga\Module\X509\Web\Control\SearchBar\ObjectSuggestions;
 use Icinga\Util\Json;
 use ipl\Html\Html;
 use ipl\Orm\Query;
-use ipl\Sql;
 use ipl\Stdlib\Filter;
 use ipl\Web\Compat\CompatController;
 use ipl\Web\Compat\SearchControls;
 use ipl\Web\Filter\QueryString;
-use PDO;
 
 class Controller extends CompatController
 {
-    use Database {
-        getDb as private getDbWithOptions;
-    }
+    use Database;
     use SearchControls {
         SearchControls::createSearchBar as private webCreateSearchBar;
     }
@@ -30,20 +26,6 @@ class Controller extends CompatController
     protected $filter;
 
     protected $format;
-
-    /**
-     * Get the connection to the X.509 database
-     *
-     * @return  Sql\Connection
-     */
-    protected function getDb()
-    {
-        $options = [
-            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC
-        ];
-
-        return $this->getDbWithOptions($options);
-    }
 
     public function fetchFilterColumns(Query $query): array
     {


### PR DESCRIPTION
Now that we're using `ipl\Orm` everywhere, there's no need to set the fetch mode to anything other than `PDO::FETCH_OBJ`.