### PR TITLE
ChainDetails: Add a context when translating `Subject`

### DIFF
--- a/library/X509/ChainDetails.php
+++ b/library/X509/ChainDetails.php
@@ -36,7 +36,7 @@ class ChainDetails extends DataTable
             ],
 
             'subject' => [
-                'label' => mt('x509', 'Subject')
+                'label' => mt('x509', 'Subject', 'x509.certificate')
             ],
 
             'ca' => [


### PR DESCRIPTION
Otherwise this is translated into `Betreff` in German.