### PR TITLE
Use `SAN` as cert name if `CN` isn't pressent

### DIFF
--- a/library/X509/CertificateDetails.php
+++ b/library/X509/CertificateDetails.php
@@ -37,11 +37,20 @@ class CertificateDetails extends BaseHtmlElement
 //        $pubkey = openssl_pkey_get_details(openssl_get_publickey($pem));
 
         $subject = Html::tag('dl');
-        foreach ($cert['subject'] as $key => $value) {
-            $subject->add([
-                Html::tag('dt', $key),
-                Html::tag('dd', $value)
-            ]);
+        $sans = CertificateUtils::splitSANs($cert['extensions']['subjectAltName'] ?? null);
+        if (! isset($cert['subject']['CN']) && ! empty($sans)) {
+            foreach ($sans as $type => $values) {
+                foreach ($values as $value) {
+                    $subject->addHtml(Html::tag('dt', $type), Html::tag('dd', $value));
+                }
+            }
+        } else {
+            foreach ($cert['subject'] as $key => $value) {
+                $subject->add([
+                    Html::tag('dt', $key),
+                    Html::tag('dd', $value)
+                ]);
+            }
         }
 
         $issuer = Html::tag('dl');


### PR DESCRIPTION
## Before
<img width="947" alt="Bildschirmfoto 2023-07-14 um 10 31 37" src="https://github.com/Icinga/icingaweb2-module-x509/assets/57616252/2a4a4606-3871-40ec-862b-2b047da4542a">

<img width="510" alt="Bildschirmfoto 2023-07-07 um 16 57 33" src="https://github.com/Icinga/icingaweb2-module-x509/assets/57616252/e3ca7653-56c3-492e-8720-1e99432131a5">

## After
<img width="947" alt="Bildschirmfoto 2023-07-14 um 10 51 19" src="https://github.com/Icinga/icingaweb2-module-x509/assets/57616252/c25cf6bc-2ffa-4a1a-b8c1-67899105d16d">

<img width="510" alt="Bildschirmfoto 2023-07-07 um 16 59 00" src="https://github.com/Icinga/icingaweb2-module-x509/assets/57616252/58f9952d-57da-471d-b789-afe96b2ce88a">


fixes #190