### PR TITLE
JobUtils: Use gmp function for checking whether an IP is inside

### DIFF
--- a/library/X509/Common/JobUtils.php
+++ b/library/X509/Common/JobUtils.php
@@ -145,10 +145,10 @@ trait JobUtils
      */
     public static function isAddrInside(GMP $addr, string $subnet, int $mask): bool
     {
-        $mask = pow(2, ((static::isIPV6($addr) ? 128 : 32) - $mask)) - 1;
-        $subnet = static::addrToNumber($subnet);
-
-        return (gmp_intval($addr) & ~$mask) === (gmp_intval($subnet) & ~$mask);
+        // `gmp_pow()` is like PHP's pow() function, but handles also very large numbers
+        // and `gmp_com()` is like the bitwise NOT (~) operator.
+        $mask = gmp_com(gmp_pow(2, (static::isIPV6($subnet) ? 128 : 32) - $mask) - 1);
+        return gmp_strval(gmp_and($addr, $mask)) === gmp_strval(gmp_and(static::addrToNumber($subnet), $mask));
     }
 
     /**


### PR DESCRIPTION
This fixes a bug with IPV6 addresses, since previously a `GMP` object was passed to `static::isIPV6()` and thus the function always returned `false`. Furthermore, the standard `PHP` `pow()` function isn't really optimal for `IPV6` either and is now replaced by `gmp_pow()` instead. Casting `GMP` objects to integer also causes many unwanted troubles when converting large numbers back with `gmp_intval()`, so `static::isAddrInside()` uses only gmp auxiliary functions.

All these problems are caught by the new unit tests added in 6536e25.