### PR TITLE
CertificateUtils: Split also unknow cert alt names correctly

### DIFF
--- a/library/X509/CertificateUtils.php
+++ b/library/X509/CertificateUtils.php
@@ -161,11 +161,16 @@ class CertificateUtils
     {
         $sans = [];
         foreach (Str::trimSplit($sanStr) as $altName) {
-            [$k, $v] = Str::trimSplit($altName, ':');
+            if (strpos($altName, ':') === false) {
+                [$k, $v] = Str::trimSplit($altName, '=', 2);
+            } else {
+                [$k, $v] = Str::trimSplit($altName, ':', 2);
+            }
+
             $sans[$k][] = $v;
         }
 
-        $order = array_flip(['DNS', 'URI', 'IP Address', 'email']);
+        $order = array_flip(['DNS', 'URI', 'IP Address', 'email', 'DirName']);
         uksort($sans, function ($a, $b) use ($order) {
             return ($order[$a] ?? PHP_INT_MAX) <=> ($order[$b] ?? PHP_INT_MAX);
         });


### PR DESCRIPTION
Failed to import certificates containing SANs like `street = Avda del Mediterraneo Etorbidea 14 - 01010 Vitoria-Gasteiz`.
```php
ERROR: ErrorException in /usr/share/icingaweb2-modules/x509/library/X509/CertificateUtils.php:163 with message: Undefined array key 1
```