### PR TITLE
Prevent from crashing the daemon

### DIFF
--- a/library/X509/Common/Database.php
+++ b/library/X509/Common/Database.php
@@ -19,7 +19,7 @@ trait Database
     protected function getDb(): Sql\Connection
     {
         $config = new Sql\Config(ResourceFactory::getResourceConfig(
-            Config::module('x509')->get('backend', 'resource')
+            Config::module('x509')->get('backend', 'resource', 'x509')
         ));
 
         $options = [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_OBJ];

--- a/library/X509/Common/JobOptions.php
+++ b/library/X509/Common/JobOptions.php
@@ -146,8 +146,8 @@ trait JobOptions
 
         /** @var stdClass $config */
         $config = $schedule->getConfig();
-        $this->setRescan($config->rescan);
-        $this->setFullScan($config->full_scan);
+        $this->setFullScan($config->full_scan ?? false);
+        $this->setRescan($config->rescan ?? false);
         $this->setLastScan($config->since_last_scan ?? Job::DEFAULT_SINCE_LAST_SCAN);
 
         return $this;


### PR DESCRIPTION
```php
ErrorException in /usr/share/icingaweb2-modules/x509/library/X509/Common/JobOptions.php:150 with message: Undefined property: stdClass::$rescan
#0 /usr/share/icingaweb2-modules/x509/library/X509/Common/JobOptions.php(150): Icinga\Application\ApplicationBootstrap->Icinga\Application\{closure}(2, 'Undefined prope...', '/usr/share/icin...', 150)
#1 /usr/share/icingaweb2-modules/x509/application/clicommands/JobsCommand.php(180): Icinga\Module\X509\Job->setSchedule(Object(Icinga\Module\X509\Schedule))
#2 /usr/share/icingaweb2-modules/x509/application/clicommands/JobsCommand.php(94): Icinga\Module\X509\Clicommands\JobsCommand->fetchSchedules('', '')
``` 