### PR TITLE
Job: Update target `last_scan` properly

### DIFF
--- a/library/X509/Job.php
+++ b/library/X509/Job.php
@@ -305,7 +305,7 @@ class Job implements Task
 
     public function updateLastScan($target)
     {
-        if (! $this->isRescan() || ! isset($target->id)) {
+        if (! $this->isRescan() && ! isset($target->id)) {
             return;
         }
 


### PR DESCRIPTION
Using the `since_last_scan` without the `rescan` flag will never update the `last_can` timestamp of a target due to this logic error.