### PR TITLE
Use `since_last_scan` flag properly

### DIFF
--- a/library/X509/Common/JobOptions.php
+++ b/library/X509/Common/JobOptions.php
@@ -20,7 +20,7 @@ trait JobOptions
     /** @var bool Whether this job should perform a full scan */
     protected $fullScan;
 
-    /** @var ?DateTime Since last scan threshold used to filter out scan targets */
+    /** @var ?string Since last scan threshold used to filter out scan targets */
     protected $sinceLastScan;
 
     /** @var int Used to control how many targets can be scanned in parallel */
@@ -97,7 +97,10 @@ trait JobOptions
             }
 
             try {
-                $this->sinceLastScan = new DateTime($sinceLastScan);
+                // Ensure it's a valid date time string representation.
+                new DateTime($sinceLastScan);
+
+                $this->sinceLastScan = $sinceLastScan;
             } catch (Exception $_) {
                 throw new InvalidArgumentException(sprintf(
                     'The specified last scan time is in an unknown format: %s',
@@ -116,7 +119,11 @@ trait JobOptions
      */
     public function getSinceLastScan(): ?DateTime
     {
-        return $this->sinceLastScan;
+        if (! $this->sinceLastScan) {
+            return null;
+        }
+
+        return new DateTime($this->sinceLastScan);
     }
 
     /**

--- a/library/X509/Job.php
+++ b/library/X509/Job.php
@@ -349,10 +349,11 @@ class Job implements Task
             yield from $this->generateTargets();
         }
 
-        if ((! $this->fullScan && $this->sinceLastScan !== null) || $this->isRescan()) {
+        $sinceLastScan = $this->getSinceLastScan();
+        if ((! $this->fullScan && $sinceLastScan !== null) || $this->isRescan()) {
             $targets = X509Target::on($this->db)->columns(['id', 'ip', 'hostname', 'port']);
-            if (! $this->fullScan && $this->sinceLastScan) {
-                $targets->filter(Filter::lessThan('last_scan', $this->sinceLastScan));
+            if (! $this->fullScan && $sinceLastScan) {
+                $targets->filter(Filter::lessThan('last_scan', $sinceLastScan));
             }
 
             foreach ($targets as $target) {


### PR DESCRIPTION
This flag is used to scan new and rescan targets that were scanned an `X` time ago, but if it gets just initialized to a `Datetime` object at daemon startup this becomes a fixed time and the daemon will never be able to rescan known targets ever again.