### PR TITLE
Do not clone jobs

### DIFF
--- a/application/clicommands/JobsCommand.php
+++ b/application/clicommands/JobsCommand.php
@@ -107,10 +107,12 @@ class JobsCommand extends Command
                 );
 
                 $scheduler->remove($job);
+
+                unset($scheduled[$job->getUuid()->toString()]);
             }
 
             $newJobs = array_diff_key($jobs, $scheduled);
-            foreach ($newJobs as $job) {
+            foreach ($newJobs as $key => $job) {
                 $job->setParallel($parallel);
 
                 /** @var stdClass $config */
@@ -131,9 +133,9 @@ class JobsCommand extends Command
                 }
 
                 $scheduler->schedule($job, $frequency);
-            }
 
-            $scheduled = $jobs;
+                $scheduled[$key] = $job;
+            }
 
             Loop::addTimer(5 * 60, $watchdog);
         };

--- a/application/clicommands/JobsCommand.php
+++ b/application/clicommands/JobsCommand.php
@@ -22,7 +22,6 @@ use ipl\Orm\Query;
 use ipl\Scheduler\Contract\Frequency;
 use ipl\Scheduler\Scheduler;
 use ipl\Stdlib\Filter;
-use Ramsey\Uuid\Uuid;
 use React\EventLoop\Loop;
 use React\Promise\ExtendedPromiseInterface;
 use stdClass;
@@ -179,11 +178,6 @@ class JobsCommand extends Command
                 $job = (new Job($jobConfig->name, $cidrs, $ports, $snimap, Schedule::fromModel($scheduleModel)))
                     ->setId($jobConfig->id)
                     ->setExcludes($this->parseExcludes($jobConfig->exclude_targets));
-
-                // The Job class sets the uuid in its constructor, but since the excluded targets are also hashed as
-                // part of the job's uuid and the excluded targets are set after the job construction, we have to
-                // reset the uuid afterwards. Otherwise, it won't notice when updating the "exclude_targets" column.
-                $job->setUuid(Uuid::fromBytes($job->getChecksum()));
 
                 $jobSchedules[$job->getUuid()->toString()] = $job;
             }

--- a/library/X509/Job.php
+++ b/library/X509/Job.php
@@ -24,6 +24,7 @@ use ipl\Sql\Expression;
 use ipl\Stdlib\Filter;
 use LogicException;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use React\EventLoop\Loop;
 use React\Promise;
 use React\Socket\ConnectionInterface;
@@ -110,7 +111,6 @@ class Job implements Task
         }
 
         $this->setName($name);
-        $this->setUuid(Uuid::fromBytes($this->getChecksum()));
     }
 
     /**
@@ -205,6 +205,15 @@ class Job implements Task
         $this->id = $id;
 
         return $this;
+    }
+
+    public function getUuid(): UuidInterface
+    {
+        if (! $this->uuid) {
+            $this->setUuid(Uuid::fromBytes($this->getChecksum()));
+        }
+
+        return $this->uuid;
     }
 
     /**


### PR DESCRIPTION
Fixes a daemon crash when reloading the configs after `5m`.
```php
Removing schedule lan Schedules of job lan, as it either no longer exists in the configuration or its config has been changed
PHP Fatal error:  Uncaught InvalidArgumentException: Task lan not scheduled in /usr/local/src/ipl-scheduler/src/Scheduler.php:158
Stack trace:
#0 /usr/share/icingaweb2-modules/x509/application/clicommands/JobsCommand.php(109): ipl\Scheduler\Scheduler->remove(Object(Icinga\Module\X509\Job))
#1 /usr/share/icinga-php/vendor/vendor/react/event-loop/src/ExtEvLoop.php(144): Icinga\Module\X509\Clicommands\JobsCommand->Icinga\Module\X509\Clicommands\{closure}(Object(React\EventLoop\Timer\Timer))
#2 [internal function]: React\EventLoop\ExtEvLoop->React\EventLoop\{closure}()
#3 /usr/share/icinga-php/vendor/vendor/react/event-loop/src/ExtEvLoop.php(208): EvLoop->run(2)
#4 /usr/share/icinga-php/vendor/vendor/react/event-loop/src/Loop.php(55): React\EventLoop\ExtEvLoop->run()
#5 [internal function]: React\EventLoop\Loop::React\EventLoop\{closure}()
#6 {main}
  thrown in /usr/local/src/ipl-scheduler/src/Scheduler.php on line 158
```