### PR TITLE
Add missing permission config/509 refs #234

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -31,3 +31,5 @@ $this->provideConfigTab('backend', array(
     'label' => $this->translate('Backend'),
     'url' => 'config/backend'
 ));
+
+$this->providePermission('config/x509', $this->translate('allow to create/update jobs/schedules/snis if permission config/* is missing'));


### PR DESCRIPTION
the permission config/509 is missing in the x509 module
It would be nice to have it since permission config/* is too much for users who should be able to create modify certificate monitoring objects.

Thanks in advance and

Best Regards

Nicolas