### PR TITLE
Change hostname datatype in table x509_target

### DIFF
--- a/schema/mysql-upgrades/1.x.0.sql
+++ b/schema/mysql-upgrades/1.x.0.sql
@@ -1,0 +1,2 @@
+ALTER TABLE x509_target
+  MODIFY COLUMN `hostname` text;

--- a/schema/mysql.schema.sql
+++ b/schema/mysql.schema.sql
@@ -71,7 +71,7 @@ CREATE TABLE x509_target (
   id int(10) unsigned NOT NULL AUTO_INCREMENT,
   ip binary(16) NOT NULL,
   `port` smallint unsigned NOT NULL,
-  hostname varchar(255) NULL DEFAULT NULL,
+  hostname text NULL DEFAULT NULL,
   latest_certificate_chain_id int(10) unsigned NULL DEFAULT NULL,
   last_scan bigint unsigned NOT NULL,
   ctime bigint unsigned DEFAULT NULL,

--- a/schema/pgsql-upgrades/1.x.0.sql
+++ b/schema/pgsql-upgrades/1.x.0.sql
@@ -1,0 +1,2 @@
+ALTER TABLE x509_target
+  MODIFY COLUMN `hostname` text;

--- a/schema/pgsql.schema.sql
+++ b/schema/pgsql.schema.sql
@@ -100,7 +100,7 @@ CREATE TABLE x509_target (
   id serial PRIMARY KEY,
   ip bytea NOT NULL,
   port uint2 NOT NULL,
-  hostname varchar(255) NULL DEFAULT NULL,
+  hostname text NULL DEFAULT NULL,
   latest_certificate_chain_id int NULL DEFAULT NULL,
   last_scan biguint NOT NULL,
   ctime biguint NOT NULL,


### PR DESCRIPTION
Change the datatype of the hostname field in the tyble x509_target from varchar(255) to text. 
If you have a very long hostname or a large number of entries in an SNI map, an error will otherwise occur during scanning.