### PR TITLE
Add scan type switcher to schedule form

### DIFF
--- a/application/controllers/JobController.php
+++ b/application/controllers/JobController.php
@@ -7,6 +7,7 @@ namespace Icinga\Module\X509\Controllers;
 
 use Icinga\Module\X509\Common\Database;
 use Icinga\Module\X509\Common\Links;
+use Icinga\Module\X509\Common\ScanType;
 use Icinga\Module\X509\Forms\Jobs\JobConfigForm;
 use Icinga\Module\X509\Forms\Jobs\ScheduleForm;
 use Icinga\Module\X509\Model\X509Job;
@@ -181,8 +182,7 @@ class JobController extends CompatController
             ->setAction((string) Url::fromRequest())
             ->populate([
                 'name'             => $schedule->name,
-                'full_scan'        => $config->full_scan ?? 'n',
-                'rescan'           => $config->rescan ?? 'n',
+                'scan_type'        => ScanType::fromConfig($config->full_scan ?? '', $config->rescan ?? '')->value,
                 'since_last_scan'  => $config->since_last_scan ?? null,
                 'schedule_element' => $frequency
             ])

--- a/application/forms/Jobs/ScheduleForm.php
+++ b/application/forms/Jobs/ScheduleForm.php
@@ -11,14 +11,17 @@ use Icinga\Application\Icinga;
 use Icinga\Application\Web;
 use Icinga\Authentication\Auth;
 use Icinga\Module\X509\Common\Database;
+use Icinga\Module\X509\Common\ScanType;
 use Icinga\Module\X509\Model\X509Schedule;
 use Icinga\User;
 use Icinga\Util\Json;
 use Icinga\Web\Notification;
+use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\Contract\FormSubmitElement;
 use ipl\Html\HtmlDocument;
 use ipl\Html\HtmlElement;
+use ipl\Html\Text;
 use ipl\Validator\CallbackValidator;
 use ipl\Web\Compat\CompatForm;
 use ipl\Web\FormElement\ScheduleElement;
@@ -97,23 +100,68 @@ class ScheduleForm extends CompatForm
             'description' => $this->translate('Schedule name'),
         ]);
 
-        $this->addElement('checkbox', 'full_scan', [
-            'required'    => false,
-            'class'       => 'autosubmit',
-            'label'       => $this->translate('Full Scan'),
-            'description' => $this->translate(
-                'Scan all known and unknown targets of this job. (Defaults to only scan unknown targets)'
-            )
-        ]);
+        $typeSwitcher = HtmlElement::create('fieldset', Attributes::create(['class' => 'type-switcher']));
+        $descriptions = HtmlElement::create('div');
+        $populatedScanType = $this->getPopulatedValue('scan_type') ?? ScanType::PARTIAL->value;
+        $request = Icinga::app()->getRequest();
 
-        if ($this->getPopulatedValue('full_scan', 'n') === 'n') {
-            $this->addElement('checkbox', 'rescan', [
-                'required'    => false,
-                'class'       => 'autosubmit',
-                'label'       => $this->translate('Rescan'),
-                'description' => $this->translate('Rescan only targets that have been scanned before')
+        foreach (ScanType::cases() as $type) {
+            // Protect the id for the case that the form is open in multiple containers
+            $protectedId = $request->protectId('scan_type-' . $type->value);
+            $chosenType = $type->value === $populatedScanType;
+
+            $descriptions->addHtml(HtmlElement::create('p', null, [
+                // Render bold label for the chosen type
+                $chosenType ? HtmlElement::create('strong', null, $type->label()) : Text::create($type->label()),
+                Text::create(': ' . $type->description())
+            ]));
+
+            $radio = $this->createElement('input', 'scan_type', [
+                'type'    => 'radio',
+                'class'   => 'autosubmit',
+                'id'      => $protectedId,
+                'value'   => $type->value,
+                'checked' => $chosenType
             ]);
 
+            // Register only the chosen element
+            if ($chosenType) {
+                $this->registerElement($radio);
+            }
+
+            $typeSwitcher->addHtml(
+                $radio,
+                HtmlElement::create(
+                    'label',
+                    Attributes::create(['for' => $protectedId, 'title' => $type->description()]),
+                    Text::create($type->label())
+                )
+            );
+        }
+
+        $this->addHtml(HtmlElement::create(
+            'div',
+            Attributes::create(['class' => 'control-group']),
+            [
+                HtmlElement::create(
+                    'div',
+                    Attributes::create(['class' => 'control-label-group']),
+                    Text::create($this->translate('Scan Type'))
+                ),
+                $typeSwitcher
+            ]
+        ));
+
+        $this->addHtml(HtmlElement::create(
+            'div',
+            Attributes::create(['class' => 'control-group no-flex-wrap']),
+            [
+                HtmlElement::create('div', Attributes::create(['class' => 'control-label-group no-flex-shrink'])),
+                $descriptions
+            ]
+        ));
+
+        if (ScanType::from($populatedScanType) !== ScanType::FULL) {
             $this->addElement('text', 'since_last_scan', [
                 'required'    => false,
                 'label'       => $this->translate('Since Last Scan'),
@@ -176,10 +224,15 @@ class ScheduleForm extends CompatForm
             $config = $this->getValues();
             unset($config['name']);
             unset($config['schedule_element']);
+            unset($config['scan_type']);
 
             $frequency = $this->scheduleElement->getValue();
             $config['type'] = get_php_type($frequency);
             $config['frequency'] = Json::encode($frequency);
+
+            $scanType = ScanType::from($this->getValue('scan_type'));
+            $config['full_scan'] = $scanType === ScanType::FULL ? 'y' : 'n';
+            $config['rescan'] = $scanType === ScanType::RE ? 'y' : 'n';
 
             /** @var User $user */
             $user = Auth::getInstance()->getUser();

--- a/configuration.php
+++ b/configuration.php
@@ -37,3 +37,5 @@ $this->providePermission(
     'config/x509',
     $this->translate('allow to create/update jobs/schedules/snis if permission config/* is missing')
 );
+
+$this->provideCssFile('type-switcher.less');

--- a/library/X509/Common/ScanType.php
+++ b/library/X509/Common/ScanType.php
@@ -22,4 +22,23 @@ enum ScanType: string
             default           => self::PARTIAL
         };
     }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::FULL    => t('Full Scan'),
+            self::PARTIAL => t('Partial Scan'),
+            self::RE      => t('Rescan')
+        };
+    }
+
+    public function description(): string
+    {
+        return match ($this) {
+            self::FULL    => t('Scan all known and unknown targets of this job.'),
+            self::PARTIAL => t('Scanning both, targets not yet scanned and targets'
+                . ' whose scan is older than the specified time.'),
+            self::RE      => t('Scan only targets that have been scanned before.')
+        };
+    }
 }

--- a/library/X509/Common/ScanType.php
+++ b/library/X509/Common/ScanType.php
@@ -1,0 +1,25 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\X509\Common;
+
+/**
+ * This enum represents the available scan types
+ */
+enum ScanType: string
+{
+    case FULL = 'full';
+    case PARTIAL = 'partial';
+    case RE = 're';
+
+    public static function fromConfig(string $fullScan, string $rescan): self
+    {
+        return match (true) {
+            $fullScan === 'y' => self::FULL,
+            $rescan === 'y'   => self::RE,
+            default           => self::PARTIAL
+        };
+    }
+}

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -170,3 +170,11 @@
 .schedule-element-separator {
   border-top: 1px solid @gray-lighter;
 }
+
+.no-flex-wrap {
+  flex-wrap: nowrap;
+}
+
+.no-flex-shrink {
+  flex-shrink: 0;
+}

--- a/public/css/type-switcher.less
+++ b/public/css/type-switcher.less
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Values are copied from Icinga Kubernetes .view-mode-switcher
+.type-switcher {
+  display: flex;
+  padding: 0;
+
+  input {
+    display: none;
+  }
+
+  label {
+    padding: 14/16*.25em 14/16*.5em;
+
+    background: @low-sat-blue;
+    color: @control-color;
+
+    cursor: pointer;
+
+    &:first-of-type {
+      border-top-left-radius: 0.25em;
+      border-bottom-left-radius: 0.25em;
+    }
+
+    &:last-of-type {
+      border-top-right-radius: 0.25em;
+      border-bottom-right-radius: 0.25em;
+    }
+
+    &:not(:last-of-type) {
+      border-right: 1px solid @low-sat-blue-dark;
+    }
+  }
+
+  input[checked] + label {
+    background-color: @control-color;
+    color: @text-color-on-icinga-blue;
+    cursor: default;
+  }
+}


### PR DESCRIPTION
Replace the checkboxes by a more modern and prettier radio switcher element. It uses the enum cases of `ScanType` to create the options to choose from. For every case a radio element is created and added to a fieldset. The fieldset is added to the `control-group`/`control-label-group` construct known from the Icinga Web forms.

In addition to the switcher element every scan type is described by a short description below. The current chosen type is hightlighted by a bold name. The descriptions are also added to the `control-group`/`control-label-group` construct, but additional css classes are applied:
- Add `.no-flex-wrap` to `control-group` element to prevent the group from wrapping, if the form shrinks.
- Add `.no-flex-shrink` to `control-label-group` to ensure that the label does not shrink, but  only the descriptions do.

### Before

<img width="790" height="124" alt="Screenshot 2026-03-10 at 08 47 51" src="https://github.com/user-attachments/assets/7c23de3e-e5e1-4d95-afc4-cc886de139df" />

### Now

<img width="790" height="188" alt="Screenshot 2026-03-10 at 08 48 07" src="https://github.com/user-attachments/assets/919a06cd-3bb7-49c1-ac6b-8e1f12a59d9d" />
